### PR TITLE
Fix error on 24-bit images and remove placeholder UI function

### DIFF
--- a/helper/decrypt_image_from_image.py
+++ b/helper/decrypt_image_from_image.py
@@ -9,9 +9,4 @@ def _lsb_to_msb(byte: int) -> int:
 
 def decrypt_image(image: Image) -> Image:
     """Decrypt the secret image from the given input image"""
-    r, g, b = image.split()
-    r.point(_lsb_to_msb)
-    g.point(_lsb_to_msb)
-    b.point(_lsb_to_msb)
-
-    return PILImage.merge("RGB", (r, g, b))
+    return image.point(_lsb_to_msb)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from nicegui import app, events, ui
 from PIL import Image
 
+from helper.decrypt_image_from_image import decrypt_image
 from helper.decrypt_text_from_image import binary_decoder
 from helper.encrypt_text import encrypt_text
 from helper.Steganographizer import Steganographizer
@@ -195,9 +196,8 @@ def decrypt_event():
         if os.path.exists(text_output_fp):
             os.remove(text_output_fp)
         # Call the function to decrypt an image from an image
-        decrypt_image = placeholder_function(cimg)
         # Save output as an image
-        decrypt_image.save(image_output_fp)
+        decrypt_image(cimg).save(image_output_fp)
     show_output()
 
 


### PR DESCRIPTION
Previously the decryption function assumed the input was 24-bit depth image and attempted to split the bands. This change makes it so that doesn't happen. Also removes the placeholder UI function in `main.py` and actually call the decrypt_image method